### PR TITLE
Restrict game words to nouns

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ No API keys are needed.
 
 ## How it works
 
-- **Round setup**: picks a target word from the common list; then fetches top associations via Datamuse (`rel_trg`), and the definition via Free Dictionary.
-- **Guesses**: each guess computes **relatedness** between the guess and the target using ConceptNet’s `/relatedness` endpoint. This drives a **temperature meter** and incremental scoring.
+- **Round setup**: picks a **noun** from the common list; then fetches top noun associations via Datamuse (`rel_trg`), and the definition via Free Dictionary.
+- **Guesses**: player entries must be nouns; each guess computes **relatedness** between the guess and the target using ConceptNet’s `/relatedness` endpoint. This drives a **temperature meter** and incremental scoring.
 - **Hints**: revealing a hint uncovers one of the top Datamuse associations (costs points). Very cold guesses will auto-reveal an extra hint to keep the game flowing.
 - **Modes**: Arcade (relaxed), Timed (90s timer), Daily (date-seeded hint order and streak tracking).
 - **Persistence**: settings and stats saved to localStorage.


### PR DESCRIPTION
## Summary
- Filter Datamuse associations and synonyms to nouns only
- Ensure dictionary lookups detect nouns and cache results
- Validate guesses and target selection to use nouns exclusively
- Document noun-only gameplay

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b138f5308322ad32c17310ac7fe2