### PR TITLE
Add ad-free Betweenle-style game with options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ No API keys are needed.
 - `styles.css` — modern gradient background, accessible palette, color-blind toggle.
 - `app.js` — all logic, including API clients, hot/cold scoring, CSV export, daily streaks, and graceful fallbacks. Includes a common word list loader for simpler targets.
 
+## Betweenle Plus
+
+A lightweight, ad-free clone of the Betweenle word guessing game.
+Options include selectable word length (4-6 letters) and a dark mode toggle.
+Load `betweenle.html` in a browser to play.
+
 ## Notes
 
 - ConceptNet relatedness values are typically ~0.05–0.40 for loosely related words; thresholds are tuned in code but easily adjustable.

--- a/betweenle.css
+++ b/betweenle.css
@@ -1,0 +1,30 @@
+body {
+  font-family: sans-serif;
+  text-align: center;
+  background: #f0f0f0;
+  color: #222;
+}
+body.dark {
+  background: #222;
+  color: #f0f0f0;
+}
+#boundaries {
+  display: flex;
+  justify-content: space-between;
+  margin: 20px auto;
+  max-width: 400px;
+  font-size: 1.2em;
+}
+#guessArea {
+  margin: 20px;
+}
+#guess {
+  text-transform: lowercase;
+}
+#history {
+  list-style: none;
+  padding: 0;
+}
+#history li {
+  margin: 5px 0;
+}

--- a/betweenle.html
+++ b/betweenle.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Betweenle Plus</title>
+  <link rel="stylesheet" href="betweenle.css">
+</head>
+<body>
+  <h1>Betweenle Plus</h1>
+  <div id="options">
+    <label for="wordLength">Word Length:</label>
+    <select id="wordLength">
+      <option value="4">4</option>
+      <option value="5" selected>5</option>
+      <option value="6">6</option>
+    </select>
+    <label><input type="checkbox" id="darkMode"> Dark Mode</label>
+  </div>
+  <div id="boundaries">
+    <span id="startWord">-----</span>
+    <span id="endWord">-----</span>
+  </div>
+  <div id="guessArea">
+    <input id="guess" placeholder="Your guess" maxlength="5" />
+    <button id="submitGuess">Guess</button>
+  </div>
+  <div id="message"></div>
+  <ul id="history"></ul>
+  <script src="betweenle.js"></script>
+</body>
+</html>

--- a/betweenle.js
+++ b/betweenle.js
@@ -1,0 +1,84 @@
+let words = [];
+let currentList = [];
+let secret = '';
+let startWord = '';
+let endWord = '';
+let guesses = 0;
+
+async function loadWords() {
+  const res = await fetch('common_words.txt');
+  const text = await res.text();
+  words = text.split(/\s+/).filter(Boolean);
+  startGame();
+}
+
+function startGame() {
+  const len = parseInt(document.getElementById('wordLength').value, 10);
+  currentList = words.filter(w => w.length === len).sort();
+  if (currentList.length === 0) {
+    document.getElementById('message').textContent = 'No words of that length.';
+    return;
+  }
+  secret = currentList[Math.floor(Math.random() * currentList.length)];
+  startWord = currentList[0];
+  endWord = currentList[currentList.length - 1];
+  guesses = 0;
+  document.getElementById('startWord').textContent = startWord;
+  document.getElementById('endWord').textContent = endWord;
+  document.getElementById('message').textContent = '';
+  document.getElementById('history').innerHTML = '';
+  const input = document.getElementById('guess');
+  input.value = '';
+  input.maxLength = len;
+  input.focus();
+}
+
+function submitGuess() {
+  const input = document.getElementById('guess');
+  let guess = input.value.trim().toLowerCase();
+  const len = parseInt(document.getElementById('wordLength').value, 10);
+  if (guess.length !== len) {
+    document.getElementById('message').textContent = `Enter a ${len}-letter word.`;
+    return;
+  }
+  if (!currentList.includes(guess)) {
+    document.getElementById('message').textContent = 'Word not in list.';
+    return;
+  }
+  guesses++;
+  if (guess === secret) {
+    document.getElementById('message').textContent = `You got it in ${guesses} guesses!`;
+    addHistory(guess, '=');
+    return;
+  }
+  if (guess < secret) {
+    startWord = guess;
+    document.getElementById('message').textContent = 'The word is after your guess.';
+    addHistory(guess, '↑');
+  } else {
+    endWord = guess;
+    document.getElementById('message').textContent = 'The word is before your guess.';
+    addHistory(guess, '↓');
+  }
+  document.getElementById('startWord').textContent = startWord;
+  document.getElementById('endWord').textContent = endWord;
+  input.value = '';
+  input.focus();
+}
+
+function addHistory(guess, indicator) {
+  const li = document.createElement('li');
+  li.textContent = `${guess} ${indicator}`;
+  document.getElementById('history').appendChild(li);
+}
+
+document.getElementById('submitGuess').addEventListener('click', submitGuess);
+document.getElementById('guess').addEventListener('keyup', (e) => {
+  if (e.key === 'Enter') submitGuess();
+});
+document.getElementById('wordLength').addEventListener('change', startGame);
+document.getElementById('darkMode').addEventListener('change', (e) => {
+  document.body.classList.toggle('dark', e.target.checked);
+});
+
+loadWords();


### PR DESCRIPTION
## Summary
- Implement new Betweenle Plus HTML, CSS, and JS files that recreate the Betweenle word game without ads.
- Include selectable word length and dark mode options.
- Document the new ad-free game in README.

## Testing
- `node --check betweenle.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c52df26083229c8e05be0170fdc0