### PR TITLE
feat: add guess counter and shareable results

### DIFF
--- a/betweenle.css
+++ b/betweenle.css
@@ -10,16 +10,21 @@ body.dark {
 }
 #boundaries {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: center;
   margin: 20px auto;
   max-width: 400px;
   font-size: 1.2em;
 }
 #guessArea {
-  margin: 20px;
+  margin: 10px 0;
 }
 #guess {
   text-transform: lowercase;
+}
+#guessCounter {
+  margin-top: 10px;
+  font-weight: bold;
 }
 #history {
   list-style: none;
@@ -27,4 +32,11 @@ body.dark {
 }
 #history li {
   margin: 5px 0;
+}
+#result {
+  margin-top: 20px;
+}
+#result pre {
+  white-space: pre-wrap;
+  margin: 0;
 }

--- a/betweenle.html
+++ b/betweenle.html
@@ -17,15 +17,17 @@
     <label><input type="checkbox" id="darkMode"> Dark Mode</label>
   </div>
   <div id="boundaries">
-    <span id="startWord">-----</span>
-    <span id="endWord">-----</span>
-  </div>
-  <div id="guessArea">
-    <input id="guess" placeholder="Your guess" maxlength="5" />
-    <button id="submitGuess">Guess</button>
+    <div id="startWord">-----</div>
+    <div id="guessArea">
+      <input id="guess" placeholder="Your guess" maxlength="5" />
+      <button id="submitGuess">Guess</button>
+      <div id="guessCounter">0/10</div>
+    </div>
+    <div id="endWord">-----</div>
   </div>
   <div id="message"></div>
   <ul id="history"></ul>
+  <div id="result"></div>
   <script src="betweenle.js"></script>
 </body>
 </html>

--- a/betweenle.js
+++ b/betweenle.js
@@ -3,7 +3,12 @@ let currentList = [];
 let secret = '';
 let startWord = '';
 let endWord = '';
+let startIdx = 0;
+let endIdx = 0;
 let guesses = 0;
+let resultsBoxes = [];
+
+const GUESS_LIMIT = 10;
 
 async function loadWords() {
   const res = await fetch('common_words.txt');
@@ -20,13 +25,18 @@ function startGame() {
     return;
   }
   secret = currentList[Math.floor(Math.random() * currentList.length)];
-  startWord = currentList[0];
-  endWord = currentList[currentList.length - 1];
+  startIdx = 0;
+  endIdx = currentList.length - 1;
+  startWord = currentList[startIdx];
+  endWord = currentList[endIdx];
   guesses = 0;
-  document.getElementById('startWord').textContent = startWord;
-  document.getElementById('endWord').textContent = endWord;
+  resultsBoxes = [];
+  updateBoundaries();
   document.getElementById('message').textContent = '';
   document.getElementById('history').innerHTML = '';
+  updateCounter();
+  document.getElementById('submitGuess').disabled = false;
+  document.getElementById('guess').disabled = false;
   const input = document.getElementById('guess');
   input.value = '';
   input.maxLength = len;
@@ -45,30 +55,71 @@ function submitGuess() {
     document.getElementById('message').textContent = 'Word not in list.';
     return;
   }
+  const guessIdx = currentList.indexOf(guess);
   guesses++;
+  let box = '';
   if (guess === secret) {
-    document.getElementById('message').textContent = `You got it in ${guesses} guesses!`;
+    box = '🟩';
     addHistory(guess, '=');
+    resultsBoxes.push(box);
+    document.getElementById('message').textContent = `You got it in ${guesses} guesses!`;
+    updateCounter();
+    endGame(true);
     return;
   }
-  if (guess < secret) {
+  if (guessIdx <= startIdx || guessIdx >= endIdx) {
+    document.getElementById('message').textContent = 'Guess out of range.';
+    addHistory(guess, '!');
+    box = '🟥';
+  } else if (guess < secret) {
     startWord = guess;
+    startIdx = guessIdx;
     document.getElementById('message').textContent = 'The word is after your guess.';
     addHistory(guess, '↑');
+    box = '🟨';
   } else {
     endWord = guess;
+    endIdx = guessIdx;
     document.getElementById('message').textContent = 'The word is before your guess.';
     addHistory(guess, '↓');
+    box = '🟨';
   }
-  document.getElementById('startWord').textContent = startWord;
-  document.getElementById('endWord').textContent = endWord;
+  resultsBoxes.push(box);
+  updateBoundaries();
+  updateCounter();
+  if (guesses >= GUESS_LIMIT) {
+    document.getElementById('message').textContent = `Out of guesses! The word was ${secret}.`;
+    endGame(false);
+  }
   input.value = '';
   input.focus();
 }
 
+function updateBoundaries() {
+  document.getElementById('startWord').textContent = `${startIdx + 1}. ${startWord}`;
+  document.getElementById('endWord').textContent = `${endIdx + 1}. ${endWord}`;
+}
+
+function updateCounter() {
+  document.getElementById('guessCounter').textContent = `${guesses}/${GUESS_LIMIT}`;
+}
+
+function endGame(won) {
+  document.getElementById('submitGuess').disabled = true;
+  document.getElementById('guess').disabled = true;
+  const score = won ? guesses : 'X';
+  const share = `Betweenle Plus ${score}/${GUESS_LIMIT}\n${resultsBoxes.join('')}\n\nPlay at ${location.href}`;
+  try {
+    navigator.clipboard.writeText(share);
+  } catch {}
+  const res = document.getElementById('result');
+  res.innerHTML = `<pre>${share}</pre><a href="${location.href}">${location.href}</a>`;
+}
+
 function addHistory(guess, indicator) {
   const li = document.createElement('li');
-  li.textContent = `${guess} ${indicator}`;
+  const idx = currentList.indexOf(guess) + 1;
+  li.textContent = `${idx}. ${guess} ${indicator}`;
   document.getElementById('history').appendChild(li);
 }
 


### PR DESCRIPTION
## Summary
- show list indices and guess counter for each round
- copy Wordle-style results with colored boxes and link
- move guess input between the two boundary words

## Testing
- `npm test` *(fails: Missing script "test" `npm error Missing script: "test"`)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d77a23108322808196650bbe8b2b