### PR TITLE
Add initial boundary clues, streak tracking, and help modal

### DIFF
--- a/betweenle.css
+++ b/betweenle.css
@@ -40,3 +40,48 @@ body.dark {
   white-space: pre-wrap;
   margin: 0;
 }
+
+.help-btn {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 50%;
+  background: #8fbcd4;
+  color: #fff;
+  font-size: 1.2em;
+  cursor: pointer;
+}
+body.dark .help-btn {
+  background: #7dd3fc;
+  color: #000;
+}
+.modal {
+  display: none;
+  position: fixed;
+  z-index: 1000;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+}
+.modal-content {
+  background: #fff;
+  color: #222;
+  margin: 10% auto;
+  padding: 20px;
+  border-radius: 8px;
+  max-width: 400px;
+  text-align: left;
+}
+body.dark .modal-content {
+  background: #333;
+  color: #f0f0f0;
+}
+.close {
+  float: right;
+  cursor: pointer;
+}

--- a/betweenle.html
+++ b/betweenle.html
@@ -6,6 +6,14 @@
   <link rel="stylesheet" href="betweenle.css">
 </head>
 <body>
+  <button id="helpBtn" class="help-btn">?</button>
+  <div id="helpModal" class="modal">
+    <div class="modal-content">
+      <span id="closeHelp" class="close">&times;</span>
+      <h2>How to Play</h2>
+      <p>Guess the secret word in as few tries as possible. Use the starting and ending words to narrow down the range. Each guess must be a valid word and the game will tell you if the secret is alphabetically before or after your guess.</p>
+    </div>
+  </div>
   <h1>Betweenle Plus</h1>
   <div id="options">
     <label for="wordLength">Word Length:</label>

--- a/betweenle.js
+++ b/betweenle.js
@@ -33,7 +33,11 @@ function startGame() {
   resultsBoxes = [];
   updateBoundaries();
   document.getElementById('message').textContent = '';
-  document.getElementById('history').innerHTML = '';
+  const history = document.getElementById('history');
+  history.innerHTML = '';
+  // show initial boundary clues
+  addHistory(startWord);
+  addHistory(endWord);
   updateCounter();
   document.getElementById('submitGuess').disabled = false;
   document.getElementById('guess').disabled = false;
@@ -112,15 +116,37 @@ function endGame(won) {
   try {
     navigator.clipboard.writeText(share);
   } catch {}
+  const streak = updateStreak(won);
   const res = document.getElementById('result');
-  res.innerHTML = `<pre>${share}</pre><a href="${location.href}">${location.href}</a>`;
+  res.innerHTML = `<pre>${share}</pre><div id="streak">Daily Streak: ${streak}</div><a href="${location.href}">${location.href}</a>`;
 }
 
-function addHistory(guess, indicator) {
+function addHistory(guess, indicator = '') {
   const li = document.createElement('li');
   const idx = currentList.indexOf(guess) + 1;
-  li.textContent = `${idx}. ${guess} ${indicator}`;
+  li.textContent = indicator ? `${idx}. ${guess} ${indicator}` : `${idx}. ${guess}`;
   document.getElementById('history').appendChild(li);
+}
+
+function updateStreak(won) {
+  let streak = parseInt(localStorage.getItem('streak') || '0', 10);
+  const today = new Date().toISOString().slice(0, 10);
+  const lastDate = localStorage.getItem('lastDate');
+  if (won) {
+    if (lastDate === today) {
+      // already counted today
+    } else if (lastDate && (new Date(today) - new Date(lastDate) === 86400000)) {
+      streak += 1;
+    } else {
+      streak = 1;
+    }
+    localStorage.setItem('lastDate', today);
+  } else {
+    streak = 0;
+    localStorage.setItem('lastDate', today);
+  }
+  localStorage.setItem('streak', streak);
+  return streak;
 }
 
 document.getElementById('submitGuess').addEventListener('click', submitGuess);
@@ -130,6 +156,17 @@ document.getElementById('guess').addEventListener('keyup', (e) => {
 document.getElementById('wordLength').addEventListener('change', startGame);
 document.getElementById('darkMode').addEventListener('change', (e) => {
   document.body.classList.toggle('dark', e.target.checked);
+});
+document.getElementById('helpBtn').addEventListener('click', () => {
+  document.getElementById('helpModal').style.display = 'block';
+});
+document.getElementById('closeHelp').addEventListener('click', () => {
+  document.getElementById('helpModal').style.display = 'none';
+});
+window.addEventListener('click', (e) => {
+  if (e.target === document.getElementById('helpModal')) {
+    document.getElementById('helpModal').style.display = 'none';
+  }
 });
 
 loadWords();


### PR DESCRIPTION
## Summary
- Show starting and ending words in history so players always see first and last index clues
- Track daily win streaks and display current streak on game completion
- Add question-mark help button that opens a modal with gameplay instructions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0d9d508148322bebece9c1b24291a