### PR TITLE
feat: render board for guesses

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,4 +1,5 @@
 import {encodeShare} from './engine/share.js';
+import {createBoard} from './board.js';
 
 const modeId = document.body.dataset.mode;
 const module = await import(`./engine/${modeId}.js`);
@@ -16,18 +17,16 @@ app.innerHTML = `
   <div id="stats" class="text-sm"></div>
 </header>
 <main class="flex flex-col h-full">
-  <div id="top" class="text-center p-2 border-b border-gray-700"></div>
+  <div id="board" class="p-2 border-b border-gray-700"></div>
   <form id="composer" class="flex gap-2 p-2 border-b border-gray-700">
     <input aria-label="Guess" autocomplete="off" class="flex-1 p-2 rounded bg-gray-800 text-gray-100" />
     <button type="submit" class="px-4 py-2 rounded bg-green-500 text-gray-900 font-semibold">Guess</button>
   </form>
-  <div id="bottom" class="text-center p-2 border-b border-gray-700"></div>
   <div id="feedback" class="text-center text-sm p-2"></div>
   <div id="attempts" class="text-center text-sm p-2"></div>
 </main>`;
 
-const topEl = document.getElementById('top');
-const bottomEl = document.getElementById('bottom');
+const board = createBoard(document.getElementById('board'));
 const feedbackEl = document.getElementById('feedback');
 const attemptsEl = document.getElementById('attempts');
 const form = document.getElementById('composer');
@@ -104,12 +103,11 @@ await startGame();
 
 function render() {
   const state = game.state;
-  topEl.textContent = state.list[state.top];
-  bottomEl.textContent = state.list[state.bottom];
+  board.render(state);
 
   const last = state.guesses[state.guesses.length-1];
   if (last) {
-    const arrow = last.idx < state.targetIdx ? '↑' : last.idx > state.targetIdx ? '↓' : '🎯';
+    const arrow = last.idx < state.targetIdx ? '↑' : last.idx > state.targetIdx ? '↓' : '';
     feedbackEl.textContent = `Index: ${last.idx} ${arrow}`;
   } else {
     feedbackEl.textContent = '';

--- a/public/board.js
+++ b/public/board.js
@@ -1,0 +1,28 @@
+export function createBoard(container) {
+  const boardEl = container;
+  boardEl.classList.add('board');
+
+  function render(state) {
+    boardEl.innerHTML = '';
+    const items = [];
+    const first = state.list[0];
+    const last = state.list[state.list.length - 1];
+    items.push(first);
+    state.guesses.forEach(g => items.push(g.value));
+    items.push(last);
+
+    items.forEach(word => {
+      const row = document.createElement('div');
+      row.className = 'board-row';
+      for (let i = 0; i < 5; i++) {
+        const tile = document.createElement('div');
+        tile.className = 'board-tile';
+        tile.textContent = word[i] ? word[i].toUpperCase() : '';
+        row.appendChild(tile);
+      }
+      boardEl.appendChild(row);
+    });
+  }
+
+  return { render };
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -56,3 +56,26 @@ main {
   padding: var(--spacing) calc(var(--spacing) * 2);
   font-size: 1rem;
 }
+.board {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.board-row {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.board-tile {
+  width: 3rem;
+  height: 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #4b5563;
+  border-radius: 0.25rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}


### PR DESCRIPTION
## Summary
- build board component to show first word, guesses, and last word
- style rows as five-letter tile grid
- integrate board into app.js replacing top/bottom text

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0ef77ffe48322a90bc58fa052171d