### PR TITLE
Add hint column to board with directional and distance cues

### DIFF
--- a/public/board.js
+++ b/public/board.js
@@ -1,25 +1,55 @@
 export function createBoard(container) {
+  const CLOSE_THRESHOLD = 5; // percent
   const boardEl = container;
   boardEl.classList.add('board');
 
   function render(state) {
     boardEl.innerHTML = '';
-    const items = [];
-    const first = state.list[0];
-    const last = state.list[state.list.length - 1];
-    items.push(first);
-    state.guesses.forEach(g => items.push(g.value));
-    items.push(last);
+    const rows = [];
+    rows.push({word: state.list[0]});
+    state.guesses.forEach(g => {
+      const distance = Math.round(
+        Math.abs(g.idx - state.targetIdx) / state.list.length * 100
+      );
+      rows.push({
+        word: g.value,
+        arrow: g.idx < state.targetIdx ? '↑' : g.idx > state.targetIdx ? '↓' : '',
+        distance,
+        close: distance < CLOSE_THRESHOLD
+      });
+    });
+    rows.push({word: state.list[state.list.length - 1]});
 
-    items.forEach(word => {
+    rows.forEach(item => {
       const row = document.createElement('div');
       row.className = 'board-row';
       for (let i = 0; i < 5; i++) {
         const tile = document.createElement('div');
         tile.className = 'board-tile';
-        tile.textContent = word[i] ? word[i].toUpperCase() : '';
+        tile.textContent = item.word[i] ? item.word[i].toUpperCase() : '';
         row.appendChild(tile);
       }
+      const hint = document.createElement('div');
+      hint.className = 'board-hint';
+      if (item.arrow) {
+        const arrow = document.createElement('span');
+        arrow.className = 'board-hint-arrow';
+        arrow.textContent = item.arrow;
+        hint.appendChild(arrow);
+      }
+      if (typeof item.distance === 'number') {
+        const dist = document.createElement('span');
+        dist.className = 'board-hint-distance';
+        dist.textContent = `${item.distance}%`;
+        hint.appendChild(dist);
+        if (item.close) {
+          const dot = document.createElement('span');
+          dot.className = 'board-hint-close';
+          dot.textContent = '•';
+          hint.appendChild(dot);
+        }
+      }
+      row.appendChild(hint);
       boardEl.appendChild(row);
     });
   }

--- a/public/styles.css
+++ b/public/styles.css
@@ -79,3 +79,27 @@ main {
   font-weight: 600;
   text-transform: uppercase;
 }
+
+.board-hint {
+  width: 3.5rem;
+  height: 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+}
+
+.board-hint-arrow {
+  font-size: 1.25rem;
+}
+
+.board-hint-distance {
+  font-size: 0.75rem;
+}
+
+.board-hint-close {
+  color: var(--accent);
+  font-size: 1.25rem;
+  line-height: 1;
+}


### PR DESCRIPTION
## Summary
- show directional arrows, distance percentage, and close-indicator dot beside each guess
- style new hint column elements

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0f092ef1c8322a5875d7ce86622a4