### PR TITLE
Add alphabet strip indicating valid letter range

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,6 +1,7 @@
 import {encodeShare} from './engine/share.js';
 import {createBoard} from './board.js';
 import {createKeyboard} from './keyboard.js';
+import {createLetterStrip} from './letter-strip.js';
 
 const modeId = document.body.dataset.mode;
 const module = await import(`./engine/${modeId}.js`);
@@ -23,6 +24,7 @@ app.innerHTML = `
     <div id="guess" class="flex-1 p-2 rounded bg-gray-800 text-gray-100"></div>
     <button type="submit" class="px-4 py-2 rounded bg-green-500 text-gray-900 font-semibold">Guess</button>
   </form>
+  <div id="letter-strip" class="p-2 border-b border-gray-700"></div>
   <div id="keyboard" class="flex flex-wrap gap-2 justify-center p-2 border-b border-gray-700"></div>
   <div id="feedback" class="text-center text-sm p-2"></div>
   <div id="attempts" class="text-center text-sm p-2"></div>
@@ -39,6 +41,7 @@ const headerEl = document.querySelector('header');
 let categorySelect = null;
 let streak = parseInt(localStorage.getItem('sandwichle-streak')||'0',10);
 let currentGuess = '';
+const letterStrip = createLetterStrip(document.getElementById('letter-strip'));
 const keyboard = createKeyboard(document.getElementById('keyboard'), {
   onLetter: ch => {
     if (currentGuess.length < 5) {
@@ -144,6 +147,7 @@ function render() {
 
   const used = attempts - state.attemptsLeft;
   attemptsEl.textContent = `Guesses: ${used}/${attempts}`;
+  letterStrip.update(state);
   keyboard.update(state, currentGuess);
 }
 

--- a/public/letter-strip.js
+++ b/public/letter-strip.js
@@ -1,0 +1,24 @@
+export function createLetterStrip(container) {
+  const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  const spans = {};
+  container.classList.add('flex', 'justify-center', 'gap-1', 'text-xs', 'mb-1');
+  letters.split('').forEach(ch => {
+    const span = document.createElement('span');
+    span.textContent = ch;
+    spans[ch] = span;
+    container.appendChild(span);
+  });
+  function update(state) {
+    const topWord = state.list[state.top];
+    const bottomWord = state.list[state.bottom];
+    const len = topWord.length;
+    for (const ch of letters) {
+      const chLower = ch.toLowerCase();
+      const min = chLower + 'a'.repeat(len - 1);
+      const max = chLower + 'z'.repeat(len - 1);
+      const allowed = !(max <= topWord || min >= bottomWord);
+      spans[ch].className = allowed ? '' : 'opacity-25';
+    }
+  }
+  return { update };
+}


### PR DESCRIPTION
## Summary
- show A–Z strip above keyboard and dim letters outside current alphabetical bounds
- update strip after each guess to reflect new range

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0f2b6fffc8322b198fb87889b7232