### PR TITLE
Inline invalid guess feedback and keyboard cleanup

### DIFF
--- a/public/keyboard.js
+++ b/public/keyboard.js
@@ -21,12 +21,12 @@ export function createKeyboard(container, {onLetter, onEnter, onBackspace} = {})
   back.addEventListener('click', () => onBackspace?.());
   keyboardEl.appendChild(back);
 
-  const enter = document.createElement('button');
-  enter.type = 'button';
-  enter.textContent = 'Enter';
-  enter.className = 'px-2 py-1 rounded bg-green-500 text-gray-900 font-semibold';
-  enter.addEventListener('click', () => onEnter?.());
-  keyboardEl.appendChild(enter);
+  const guess = document.createElement('button');
+  guess.type = 'button';
+  guess.textContent = 'Guess';
+  guess.className = 'px-2 py-1 rounded bg-green-500 text-gray-900 font-semibold';
+  guess.addEventListener('click', () => onEnter?.());
+  keyboardEl.appendChild(guess);
 
   function update(state, guess = '') {
     const topWord = state.list[state.top];
@@ -43,7 +43,7 @@ export function createKeyboard(container, {onLetter, onEnter, onBackspace} = {})
       btn.disabled = disabled;
     }
     back.disabled = len === 0;
-    enter.disabled = len !== 5;
+    guess.disabled = len !== 5;
   }
 
   return {update};


### PR DESCRIPTION
## Summary
- Display invalid guesses inline instead of with an alert
- Clear invalid guess message on user input and after valid guesses
- Enable typing from device keyboards and move Guess button to on-screen keyboard

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0f41b40a08322ba1c06811b3a30a9