### PR TITLE
Display distance/arrow hints and freeze input on win

### DIFF
--- a/public/board.js
+++ b/public/board.js
@@ -8,14 +8,12 @@ export function createBoard(container) {
     const rows = [];
     rows.push({word: state.list[0]});
     state.guesses.forEach(g => {
-      const distance = Math.round(
-        Math.abs(g.idx - state.targetIdx) / state.list.length * 100
-      );
       rows.push({
         word: g.value,
-        arrow: g.idx < state.targetIdx ? '↑' : g.idx > state.targetIdx ? '↓' : '',
-        distance,
-        close: distance < CLOSE_THRESHOLD
+        arrow: g.arrow,
+        distance: g.distance,
+        close: g.distance < CLOSE_THRESHOLD,
+        win: g.win
       });
     });
     rows.push({word: state.list[state.list.length - 1]});
@@ -23,6 +21,7 @@ export function createBoard(container) {
     rows.forEach(item => {
       const row = document.createElement('div');
       row.className = 'board-row';
+      if (item.win) row.classList.add('win');
       for (let i = 0; i < 5; i++) {
         const tile = document.createElement('div');
         tile.className = 'board-tile';

--- a/public/styles.css
+++ b/public/styles.css
@@ -80,6 +80,12 @@ main {
   text-transform: uppercase;
 }
 
+.board-row.win .board-tile {
+  background-color: #22c55e;
+  border-color: #16a34a;
+  color: #111;
+}
+
 .board-hint {
   width: 3.5rem;
   height: 3rem;


### PR DESCRIPTION
## Summary
- compute arrow and distance from engine results for each guess
- show guess metrics on the board and highlight winning guess
- disable further input after victory

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a0f9bd265483229ae6986b1bdce810