### PR TITLE
Add guess band scoring and attempt indicators

### DIFF
--- a/public/state.js
+++ b/public/state.js
@@ -1,0 +1,25 @@
+export const GUESS_BANDS = [5, 3, 3, 2, 1];
+
+export const BAND_COLORS = [
+  'bg-green-500',
+  'bg-sky-500',
+  'bg-yellow-500',
+  'bg-orange-500',
+  'bg-red-500'
+];
+
+export function getBandForGuess(count) {
+  let total = 0;
+  for (let i = 0; i < GUESS_BANDS.length; i++) {
+    total += GUESS_BANDS[i];
+    if (count <= total) {
+      return i;
+    }
+  }
+  return GUESS_BANDS.length - 1;
+}
+
+export function getScoreForGuess(count) {
+  const band = getBandForGuess(count);
+  return GUESS_BANDS.length - band;
+}


### PR DESCRIPTION
## Summary
- Track guess band distribution and scoring helpers in new `state.js`
- Show current guess number and remaining attempt circles
- Display score based on attempt band when player wins

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0faff53548322988f885c6e25d621