### PR TITLE
feat: add landing page with streak and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,6 @@
     </style>
   </head>
   <body>
-    <a class="play" href="public/sandwichle.html">Play Sandwichle++</a>
+    <a class="play" href="public/index.html">Play Sandwichle++</a>
   </body>
 </html>

--- a/public/how-to-play.html
+++ b/public/how-to-play.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>How to Play - Sandwichle++</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen flex flex-col items-center justify-center bg-gray-900 text-gray-100 p-4">
+  <main class="max-w-md w-full">
+    <h1 class="text-2xl font-semibold mb-4">How to Play</h1>
+    <p class="mb-4">Guess the secret item that lies alphabetically between two others. Each guess narrows the range. Find the target before you run out of attempts!</p>
+    <a href="./index.html" class="text-blue-400">&larr; Back</a>
+  </main>
+</body>
+</html>
+

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sandwichle++</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen flex flex-col items-center justify-center gap-4 bg-gray-900 text-gray-100">
+  <h1 class="text-2xl font-semibold">Sandwichle++</h1>
+  <div id="streak" class="text-lg"></div>
+  <div class="flex flex-col gap-2 w-64">
+    <a href="./sandwichle.html" class="px-4 py-2 rounded bg-green-500 text-gray-900 text-center font-semibold">Daily Puzzle</a>
+    <a href="./sandwichle.html?practice=1" class="px-4 py-2 rounded bg-blue-500 text-gray-100 text-center font-semibold">Practice / Levels</a>
+    <a href="./how-to-play.html" class="px-4 py-2 rounded bg-gray-700 text-gray-100 text-center font-semibold">How to Play</a>
+  </div>
+  <script>
+    const streak = localStorage.getItem('sandwichle-streak') || 0;
+    document.getElementById('streak').textContent = `Current Streak: ${streak}`;
+  </script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- add landing page with Daily, Practice, and How to Play options
- show current streak on landing page
- update entry point to use new landing page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a0feb374408322bb12f0eadd1b7e28