### PR TITLE
Re-render board on letter edits

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -54,7 +54,8 @@ const keyboard = createKeyboard(document.getElementById('keyboard'), {
     if (currentGuess.length < 5) {
       clearError();
       currentGuess += ch.toLowerCase();
-      render();
+      board.render(game.state, currentGuess);
+      keyboard.update(game.state, currentGuess);
     }
   },
   onBackspace: () => {
@@ -62,7 +63,8 @@ const keyboard = createKeyboard(document.getElementById('keyboard'), {
     if (currentGuess.length) {
       clearError();
       currentGuess = currentGuess.slice(0, -1);
-      render();
+      board.render(game.state, currentGuess);
+      keyboard.update(game.state, currentGuess);
     }
   },
   onEnter: () => {


### PR DESCRIPTION
## Summary
- Re-render board with current guess on every keyboard letter input
- Update keyboard availability alongside board refresh

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a103161d1483229a663e352721a9f7