### PR TITLE
Allow shorter word lists

### DIFF
--- a/public/engine/words.js
+++ b/public/engine/words.js
@@ -31,8 +31,8 @@ async function loadList(slug) {
   const uniq = Array.from(new Set(norm));
   const targetLen = uniq[0]?.length || 0;
   const filtered = uniq.filter(w => w.length === targetLen);
-  if (filtered.length < 100) {
-    throw new Error('Category requires at least 100 single words of equal length');
+  if (filtered.length !== uniq.length) {
+    throw new Error('Category requires all words to be the same length');
   }
   filtered.sort((a,b)=>a.localeCompare(b,'en',{sensitivity:'base'}));
   return {list: filtered, info};


### PR DESCRIPTION
## Summary
- relax word list requirement by removing 100-word minimum
- ensure all words in a category share the same length

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a105de1214832296b33a936cc2a34a