### PR TITLE
Refine board cues and layout

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -96,7 +96,7 @@ function saveHistory(win, guesses) {
 }
 
 function updateStats(){
-  statsEl.textContent = `Streak: ${streak} 🏆${trophies}`;
+  statsEl.innerHTML = `<div>Streak: ${streak}</div><div>Trophies: ${trophies}</div>`;
 }
 updateStats();
 
@@ -141,7 +141,6 @@ function submitGuess() {
   const lastGuess = res.state.guesses[res.state.guesses.length-1];
   lastGuess.arrow = arrow;
   lastGuess.win = res.win;
-  lastGuess.distance = res.distance;
   clearError();
   currentGuess = '';
   render();
@@ -200,7 +199,7 @@ function render() {
 
   const last = state.guesses[state.guesses.length-1];
   if (last) {
-    feedbackEl.textContent = `Distance: ${last.distance}% ${last.arrow || ''}`;
+    feedbackEl.textContent = `Index: ${last.idx+1} ${last.arrow || ''}`;
   } else {
     feedbackEl.textContent = '';
   }

--- a/public/board.js
+++ b/public/board.js
@@ -1,5 +1,4 @@
 export function createBoard(container) {
-  const CLOSE_THRESHOLD = 5; // percent
   const boardEl = container;
   boardEl.classList.add('board');
 
@@ -7,27 +6,18 @@ export function createBoard(container) {
     boardEl.innerHTML = '';
     const rows = [];
     // top cue
-    rows.push({word: state.list[state.top]});
-    // previous guesses
-    state.guesses.forEach(g => {
-      rows.push({
-        word: g.value,
-        arrow: g.arrow,
-        distance: g.distance,
-        close: g.distance < CLOSE_THRESHOLD,
-        win: g.win
-      });
-    });
+    rows.push({word: state.list[state.top], idx: state.top, cue: true});
     // current in-progress guess
     if (guess !== undefined) {
       rows.push({word: guess});
     }
     // bottom cue
-    rows.push({word: state.list[state.bottom]});
+    rows.push({word: state.list[state.bottom], idx: state.bottom, cue: true});
 
     rows.forEach(item => {
       const row = document.createElement('div');
       row.className = 'board-row';
+      if (item.cue) row.classList.add('cue');
       if (item.win) row.classList.add('win');
       for (let i = 0; i < 5; i++) {
         const tile = document.createElement('div');
@@ -43,17 +33,11 @@ export function createBoard(container) {
         arrow.textContent = item.arrow;
         hint.appendChild(arrow);
       }
-      if (typeof item.distance === 'number') {
-        const dist = document.createElement('span');
-        dist.className = 'board-hint-distance';
-        dist.textContent = `${item.distance}%`;
-        hint.appendChild(dist);
-        if (item.close) {
-          const dot = document.createElement('span');
-          dot.className = 'board-hint-close';
-          dot.textContent = '•';
-          hint.appendChild(dot);
-        }
+      if (typeof item.idx === 'number') {
+        const idx = document.createElement('span');
+        idx.className = 'board-hint-distance';
+        idx.textContent = `#${item.idx+1}`;
+        hint.appendChild(idx);
       }
       row.appendChild(hint);
       boardEl.appendChild(row);

--- a/public/styles.css
+++ b/public/styles.css
@@ -66,6 +66,7 @@ main {
 .board-row {
   display: flex;
   gap: 0.25rem;
+  justify-content: center;
 }
 
 .board-tile {
@@ -84,6 +85,12 @@ main {
   background-color: #22c55e;
   border-color: #16a34a;
   color: #111;
+}
+
+.board-row.cue .board-tile {
+  background-color: #3b82f6;
+  border-color: #2563eb;
+  color: #fff;
 }
 
 .board-hint {


### PR DESCRIPTION
## Summary
- Highlight cue words and center board tiles
- Display index hints for cues and last guesses
- Separate streak and trophies, keep board free of guess history

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a10d6d01dc8322be2b5a8690a31dad