### PR TITLE
feat: replace trophies label with emoji

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -96,7 +96,7 @@ function saveHistory(win, guesses) {
 }
 
 function updateStats(){
-  statsEl.innerHTML = `<div>Streak: ${streak}</div><div>Trophies: ${trophies}</div>`;
+  statsEl.innerHTML = `<div>Streak: ${streak}</div><div aria-label="Trophies: ${trophies}">🏆 ${trophies}</div>`;
 }
 updateStats();
 


### PR DESCRIPTION
## Summary
- use trophy emoji in stats instead of text label

## Testing
- `npm test` (fails: Missing script)
- `npm run build`
- `node -e 'let streak=1, trophies=1; const statsEl={innerHTML:""}; function updateStats(){ statsEl.innerHTML = `<div>Streak: ${streak}</div><div aria-label="Trophies: ${trophies}">🏆 ${trophies}</div>`; } updateStats(); console.log(statsEl.innerHTML);'`


------
https://chatgpt.com/codex/tasks/task_e_68a1144e207083228f344852a066c496