### PR TITLE
feat: scale attempts and trophy rewards

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -9,8 +9,8 @@ const modeId = document.body.dataset.mode;
 const module = await import(`./engine/${modeId}.js`);
 const params = new URLSearchParams(location.search);
 const daily = !params.has('practice');
-const MAX_ATTEMPTS = GUESS_BANDS.reduce((a,b)=>a+b,0);
-const attempts = daily ? MAX_ATTEMPTS : parseInt(params.get('attempts')||String(MAX_ATTEMPTS),10);
+const DEFAULT_MAX_ATTEMPTS = GUESS_BANDS.reduce((a,b)=>a+b,0);
+let attempts;
 let game;
 const mode = modeId;
 
@@ -118,10 +118,12 @@ if (mode === 'words' && module.loadManifest) {
 
 async function startGame() {
   if (mode === 'words' && categorySelect) {
-    game = await module.newGame({daily, attempts, category: categorySelect.value});
+    game = await module.newGame({daily, category: categorySelect.value});
   } else {
-    game = module.newGame({daily, attempts});
+    const max = daily ? DEFAULT_MAX_ATTEMPTS : parseInt(params.get('attempts')||String(DEFAULT_MAX_ATTEMPTS),10);
+    game = await module.newGame({daily, attempts: max});
   }
+  attempts = game.state.guesses.length + game.state.attemptsLeft;
   currentGuess = '';
   gameOver = false;
   score = 0;
@@ -147,7 +149,7 @@ function submitGuess() {
   if (res.win) {
     gameOver = true;
     streak++;
-    trophies++;
+    trophies += module.trophyReward ?? 1;
     localStorage.setItem('sandwichle-streak', streak);
     localStorage.setItem('sandwichle-trophies', trophies);
     updateStats();

--- a/public/engine/words.js
+++ b/public/engine/words.js
@@ -4,6 +4,17 @@ import {yyyyMMddUTC, seedOf, rng} from './seed.js';
 const MANIFEST_URL = new URL('../data/words/manifest.json', import.meta.url);
 let manifestCache = null;
 
+export let trophyReward = 1;
+
+export function getAttemptSettings(len) {
+  if (len > 1000) return {attempts: 20, trophyReward: 5};
+  if (len > 500) return {attempts: 15, trophyReward: 4};
+  if (len > 250) return {attempts: 10, trophyReward: 3};
+  if (len > 100) return {attempts: 5, trophyReward: 2};
+  if (len <= 50) return {attempts: 3, trophyReward: 1};
+  return {attempts: 4, trophyReward: 2};
+}
+
 export async function loadManifest() {
   if (!manifestCache) {
     manifestCache = await fetch(MANIFEST_URL).then(r => r.json());
@@ -33,8 +44,12 @@ async function loadList(slug) {
 
 const SALT = import.meta.env?.VITE_WORDS_SALT || 'words';
 
-export async function newGame({daily=true, attempts=14, category='general'}={}) {
+export async function newGame({daily=true, category='general'}={}) {
   const {list} = await loadList(category);
+  const len = list.length;
+  const settings = getAttemptSettings(len);
+  trophyReward = settings.trophyReward;
+  const attempts = settings.attempts;
   let idx;
   if (daily) {
     const s = seedOf(yyyyMMddUTC(), 'words', category, SALT);


### PR DESCRIPTION
## Summary
- compute word list length and derive attempts and trophy rewards via `getAttemptSettings`
- expose trophy reward, use dynamic attempt count in app logic, and award trophies accordingly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1262e0f3483229f0925e90acd9b1f