### PR TITLE
feat: add new word button

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -116,6 +116,12 @@ if (mode === 'words' && module.loadManifest) {
   headerEl.appendChild(categorySelect);
 }
 
+const newWordBtn = document.createElement('button');
+newWordBtn.textContent = 'New Word';
+newWordBtn.className = 'w-full p-2 rounded bg-blue-600 text-white';
+newWordBtn.addEventListener('click', () => startGame());
+headerEl.appendChild(newWordBtn);
+
 async function startGame() {
   if (mode === 'words' && categorySelect) {
     game = await module.newGame({daily, category: categorySelect.value});


### PR DESCRIPTION
## Summary
- add a "New Word" button to restart the puzzle with the current category
- style the button with Tailwind classes and append it to the header

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a12993276883229f4b387ad4aa8c48