### PR TITLE
feat: prevent zoom on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
     <title>Sandwichle++</title>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
     <style>
@@ -14,6 +14,7 @@
         align-items: center;
         justify-content: center;
         min-height: 100vh;
+        touch-action: manipulation;
       }
       a.play {
         padding: 1rem 2rem;

--- a/public/how-to-play.html
+++ b/public/how-to-play.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>How to Play - Sandwichle++</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="min-h-screen flex flex-col items-center justify-center bg-gray-900 text-gray-100 p-4">
+<body class="min-h-screen flex flex-col items-center justify-center bg-gray-900 text-gray-100 p-4" style="touch-action: manipulation;">
   <main class="max-w-md w-full">
     <h1 class="text-2xl font-semibold mb-4">How to Play</h1>
     <p class="mb-4">Guess the secret item that lies alphabetically between two others. Each guess narrows the range. Find the target before you run out of attempts!</p>

--- a/public/index.html
+++ b/public/index.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>Sandwichle++</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="min-h-screen flex flex-col items-center justify-center gap-4 bg-gray-900 text-gray-100">
+<body class="min-h-screen flex flex-col items-center justify-center gap-4 bg-gray-900 text-gray-100" style="touch-action: manipulation;">
   <h1 class="text-2xl font-semibold">Sandwichle++</h1>
   <div id="streak" class="text-lg"></div>
   <div class="flex flex-col gap-2 w-64">

--- a/public/sandwichle.html
+++ b/public/sandwichle.html
@@ -2,13 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>Sandwichle++ Words</title>
   <link rel="stylesheet" href="./styles.css">
   <link rel="manifest" href="./manifest.webmanifest">
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body data-mode="words" class="min-h-screen bg-gray-900 text-gray-100">
+<body data-mode="words" class="min-h-screen bg-gray-900 text-gray-100" style="touch-action: manipulation;">
   <div id="app" class="max-w-md mx-auto p-4"></div>
   <script type="module" src="./app.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- disable browser zoom with a locked viewport setting
- apply inline touch-action to body tags to curb double-tap zooming
- add words data directory for future word lists

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a12c322c448322805f06806c058256