### PR TITLE
Build word categories from CSV files

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -111,7 +111,8 @@ if (mode === 'words' && module.loadManifest) {
     categorySelect.appendChild(opt);
   });
   const stored = localStorage.getItem('sandwichle-category');
-  categorySelect.value = stored && manifest[stored] ? stored : 'icecream';
+  const defaultCat = Object.keys(manifest)[0];
+  categorySelect.value = stored && manifest[stored] ? stored : defaultCat;
   localStorage.setItem('sandwichle-category', categorySelect.value);
   headerEl.appendChild(categorySelect);
 }

--- a/public/data/words/manifest.json
+++ b/public/data/words/manifest.json
@@ -1,0 +1,130 @@
+{
+  "adjectives": {
+    "file": "./adjectives_5letter.csv",
+    "name": "adjectives"
+  },
+  "animals": {
+    "file": "./animals_5letter.csv",
+    "name": "animals"
+  },
+  "beverages": {
+    "file": "./beverages_5letter.csv",
+    "name": "beverages"
+  },
+  "birds": {
+    "file": "./birds_5letter.csv",
+    "name": "birds"
+  },
+  "body_parts": {
+    "file": "./body_parts_5letter.csv",
+    "name": "body_parts"
+  },
+  "car_brands": {
+    "file": "./car_brands_5letter.csv",
+    "name": "car_brands"
+  },
+  "cities": {
+    "file": "./cities_5letter.csv",
+    "name": "cities"
+  },
+  "clothing": {
+    "file": "./clothing_5letter.csv",
+    "name": "clothing"
+  },
+  "college_majors": {
+    "file": "./college_majors_5letter.csv",
+    "name": "college_majors"
+  },
+  "colors": {
+    "file": "./colors_5letter.csv",
+    "name": "colors"
+  },
+  "common_nouns": {
+    "file": "./common_nouns_5letter.csv",
+    "name": "common_nouns"
+  },
+  "common_verbs": {
+    "file": "./common_verbs_5letter.csv",
+    "name": "common_verbs"
+  },
+  "countries": {
+    "file": "./countries_5letter.csv",
+    "name": "countries"
+  },
+  "countries_cities": {
+    "file": "./countries_cities_5letter.csv",
+    "name": "countries_cities"
+  },
+  "desserts": {
+    "file": "./desserts_5letter.csv",
+    "name": "desserts"
+  },
+  "first_names": {
+    "file": "./first_names_5letter.csv",
+    "name": "first_names"
+  },
+  "fish_sealife": {
+    "file": "./fish_sealife_5letter.csv",
+    "name": "fish_sealife"
+  },
+  "flowers": {
+    "file": "./flowers_5letter.csv",
+    "name": "flowers"
+  },
+  "foods": {
+    "file": "./foods_5letter.csv",
+    "name": "foods"
+  },
+  "fruits": {
+    "file": "./fruits_5letter.csv",
+    "name": "fruits"
+  },
+  "fruits_veggies": {
+    "file": "./fruits_veggies_5letter.csv",
+    "name": "fruits_veggies"
+  },
+  "icecream_flavors": {
+    "file": "./icecream_flavors_5letter.csv",
+    "name": "icecream_flavors"
+  },
+  "instruments": {
+    "file": "./instruments_5letter.csv",
+    "name": "instruments"
+  },
+  "jobs": {
+    "file": "./jobs_5letter.csv",
+    "name": "jobs"
+  },
+  "kitchen_items": {
+    "file": "./kitchen_items_5letter.csv",
+    "name": "kitchen_items"
+  },
+  "math_terms": {
+    "file": "./math_terms_5letter.csv",
+    "name": "math_terms"
+  },
+  "programming_terms": {
+    "file": "./programming_terms_5letter.csv",
+    "name": "programming_terms"
+  },
+  "sports": {
+    "file": "./sports_5letter.csv",
+    "name": "sports"
+  },
+  "tools": {
+    "file": "./tools_5letter.csv",
+    "name": "tools"
+  },
+  "transport": {
+    "file": "./transport_5letter.csv",
+    "name": "transport"
+  },
+  "video_games": {
+    "file": "./video_games_5letter.csv",
+    "name": "video_games"
+  },
+  "weather": {
+    "file": "./weather_5letter.csv",
+    "name": "weather"
+  }
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'sandwichlepp-v2';
+const CACHE = 'sandwichlepp-v3';
 const ASSETS = [
   '/public/sandwichle.html',
   '/public/numbers.html',
@@ -7,8 +7,7 @@ const ASSETS = [
   '/public/pokemon.html',
   '/public/app.js',
   '/public/styles.css',
-  '/public/data/words/manifest.json',
-  '/public/data/words/icecream.json'
+  '/public/data/words/manifest.json'
 ];
 self.addEventListener('install', e => {
   e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)));

--- a/scripts/build_word_lists.py
+++ b/scripts/build_word_lists.py
@@ -2,95 +2,24 @@ import json
 import re
 from pathlib import Path
 
-import requests
-from wordfreq import zipf_frequency
 
 DATA_DIR = Path(__file__).resolve().parent.parent / 'public' / 'data' / 'words'
-DATA_DIR.mkdir(parents=True, exist_ok=True)
-
 MANIFEST = {}
 
 
-def add_csv(slug, name):
-    """Register an existing CSV list with the manifest."""
-    path = DATA_DIR / f"{slug}.csv"
-    with open(path, "r", encoding="utf-8") as f:
-        words = [line.strip().lower() for line in f if line.strip()]
-    for w in words:
-        if not re.fullmatch(r"[a-z]{5}", w):
-            raise ValueError(f"{slug} list contains invalid word: {w}")
-    MANIFEST[slug] = {"file": f"./{slug}.csv", "name": name}
+def build_manifest():
+    """Scan DATA_DIR for CSV files and build manifest.json."""
+    pattern = re.compile(r'_5letters?$')
+    for path in sorted(DATA_DIR.glob('*.csv')):
+        slug_with_suffix = path.stem
+        slug = pattern.sub('', slug_with_suffix)
+        MANIFEST[slug] = {"file": f"./{path.name}", "name": slug}
 
-
-def write_csv(slug, name, words):
-    """Normalize, dedupe, write out a CSV list and register it."""
-    norm = [w.strip().lower() for w in words if w]
-    norm = [re.sub(r"[^a-z' -]", '', w) for w in norm]
-    norm = [w for w in norm if w]
-    uniq = []
-    existing = set()
-    for w in norm:
-        if w not in existing:
-            uniq.append(w)
-            existing.add(w)
-    path = DATA_DIR / f"{slug}.csv"
-    with open(path, "w", encoding="utf-8") as f:
-        f.write("\n".join(uniq))
-    MANIFEST[slug] = {"file": f"./{slug}.csv", "name": name}
-
-
-# --- General 5-letter words from english words list + frequency filter ---
-
-def build_general_words():
-    url = "https://raw.githubusercontent.com/dwyl/english-words/master/words_alpha.txt"
-    txt = requests.get(url, timeout=30).text
-    words = [w for w in txt.split() if len(w) == 5 and zipf_frequency(w, "en") >= 3]
-    write_csv("general", "General 5-letter Words", words)
-
-
-# --- Countries from REST Countries API ---
-
-def build_countries():
-    url = 'https://restcountries.com/v3.1/all?fields=name'
-    data = requests.get(url, timeout=60).json()
-    names = []
-    for c in data:
-        name = c.get('name', {}).get('common')
-        if name and len(name) == 5:
-            names.append(name)
-    names.sort(key=lambda x: x.lower())
-    write_csv("countries", "Countries", names)
-
-
-# --- Pokémon from PokéAPI ---
-
-def build_pokemon():
-    url = 'https://pokeapi.co/api/v2/pokemon?limit=100000'
-    data = requests.get(url, timeout=60).json()
-    items = []
-    for p in data.get('results', []):
-        name = p['name']
-        m = re.search(r"/pokemon/(\d+)/", p['url'])
-        dex = int(m.group(1)) if m else None
-        if dex is not None and len(name) == 5:
-            items.append((dex, name))
-    items.sort(key=lambda x: x[0])
-    names = [name for _, name in items]
-    write_csv("pokemon", "Pokémon", names)
-
-
-def main():
-    build_general_words()
-    add_csv("icecream", "Icecream Flavors")
-    add_csv("majors", "College Majors")
-    add_csv("animals", "Animals")
-    build_countries()
-    build_pokemon()
-    # Write manifest
-    manifest_path = DATA_DIR / "manifest.json"
-    with open(manifest_path, "w", encoding="utf-8") as f:
+    manifest_path = DATA_DIR / 'manifest.json'
+    with open(manifest_path, 'w', encoding='utf-8') as f:
         json.dump(MANIFEST, f, ensure_ascii=False, indent=2)
 
 
 if __name__ == '__main__':
-    main()
+    build_manifest()
+


### PR DESCRIPTION
## Summary
- Generate `public/data/words/manifest.json` dynamically by scanning `.csv` files
- Default category selection to the first entry from the manifest
- Update service worker cache and remove obsolete icecream list

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a12f9a726c8322bbb31cee712e3b7f