### PR TITLE
fix: ignore header rows in word lists

### DIFF
--- a/public/engine/words.js
+++ b/public/engine/words.js
@@ -29,6 +29,12 @@ async function loadList(slug) {
   const dataUrl = new URL(info.file, MANIFEST_URL);
   const text = await fetch(dataUrl).then(r => r.text());
   const list = text.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
+  // Some of the word lists include a header row such as "word".  The
+  // gameplay engine expects a simple list of words, so remove a leading
+  // header if present to avoid treating it as an actual guessable word.
+  if (list[0]?.toLowerCase() === 'word') {
+    list.shift();
+  }
   const norm = list
     .map(s => s.normalize('NFC').toLowerCase())
     .filter(w => /^[a-z]+$/.test(w));


### PR DESCRIPTION
## Summary
- Ignore header rows such as `word` when loading category word lists
- Prevents invalid 4-letter entries from causing rendering failures

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a13a2ec3a08322b3aa707a8c5729dc