### PR TITLE
Add hint button fetching word definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A static, mobile-first guessing game where you find the secret entry sandwiched alphabetically between two others, with multiple modes (words, numbers, countries, dates, Pokémon).
 
+In word mode, a new **Hint** button fetches the target word's definition from an online dictionary API to help you guess.
+
 ## Development
 
 ```

--- a/public/app.js
+++ b/public/app.js
@@ -123,6 +123,22 @@ newWordBtn.className = 'w-full p-2 rounded bg-blue-600 text-white';
 newWordBtn.addEventListener('click', () => startGame());
 headerEl.appendChild(newWordBtn);
 
+const hintBtn = document.createElement('button');
+hintBtn.textContent = 'Hint';
+hintBtn.className = 'w-full p-2 rounded bg-yellow-500 text-gray-900';
+hintBtn.addEventListener('click', async () => {
+  if (!game || !game.state?.target) return;
+  try {
+    const res = await fetch(`https://api.dictionaryapi.dev/api/v2/entries/en/${game.state.target}`);
+    const data = await res.json();
+    const definition = data[0]?.meanings?.[0]?.definitions?.[0]?.definition;
+    alert(definition ? `Definition: ${definition}` : 'No definition found.');
+  } catch (err) {
+    alert('Error fetching definition.');
+  }
+});
+headerEl.appendChild(hintBtn);
+
 async function startGame() {
   if (mode === 'words' && categorySelect) {
     game = await module.newGame({daily, category: categorySelect.value});


### PR DESCRIPTION
## Summary
- add Hint button that fetches the target word's definition from dictionaryapi.dev
- document Hint button in README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a13d87bc688322bd6d79e6eebe7571