### PR TITLE
Streamline Sandwichle landing and game UI

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -19,7 +19,6 @@ app.innerHTML = `
 <header class="flex flex-col items-center gap-2 mb-4">
   <h1 class="text-2xl font-semibold">Sandwichle++</h1>
   <div id="countdown" class="text-sm opacity-75"></div>
-  <div id="stats" class="text-sm"></div>
   <div id="score" class="text-sm"></div>
 </header>
 <main class="flex flex-col h-full">
@@ -39,7 +38,6 @@ const feedbackEl = document.getElementById('feedback');
 const attemptTextEl = document.getElementById('attempt-text');
 const attemptCirclesEl = document.getElementById('attempt-circles');
 const countdownEl = document.getElementById('countdown');
-const statsEl = document.getElementById('stats');
 const scoreEl = document.getElementById('score');
 const headerEl = document.querySelector('header');
 const controlsEl = document.getElementById('controls');
@@ -97,10 +95,6 @@ function saveHistory(win, guesses) {
   localStorage.setItem('sandwichle-history', JSON.stringify(history));
 }
 
-function updateStats(){
-  statsEl.innerHTML = `<div>Streak: ${streak}</div><div aria-label="Trophies: ${trophies}">🏆 ${trophies}</div>`;
-}
-updateStats();
 
 if (mode === 'words' && module.loadManifest) {
   const manifest = await module.loadManifest();
@@ -193,7 +187,6 @@ function submitGuess() {
     trophies += module.trophyReward ?? 1;
     localStorage.setItem('sandwichle-streak', streak);
     localStorage.setItem('sandwichle-trophies', trophies);
-    updateStats();
     score = getScoreForGuess(game.state.guesses.length);
     scoreEl.textContent = `Score: ${score}/5`;
     render();
@@ -211,7 +204,6 @@ function submitGuess() {
     gameOver = true;
     streak = 0;
     localStorage.setItem('sandwichle-streak', streak);
-    updateStats();
     render();
     saveHistory(false, game.state.guesses.length);
     const share = encodeShare(game.state.guesses, game.state.targetIdx);

--- a/public/index.html
+++ b/public/index.html
@@ -8,15 +8,18 @@
 </head>
 <body class="min-h-screen flex flex-col items-center justify-center gap-4 bg-gray-900 text-gray-100" style="touch-action: manipulation;">
   <h1 class="text-2xl font-semibold">Sandwichle++</h1>
-  <div id="streak" class="text-lg"></div>
+  <div id="stats" class="text-lg text-center"></div>
   <div class="flex flex-col gap-2 w-64">
-    <a href="./sandwichle.html" class="px-4 py-2 rounded bg-green-500 text-gray-900 text-center font-semibold">Daily Puzzle</a>
-    <a href="./sandwichle.html?practice=1" class="px-4 py-2 rounded bg-blue-500 text-gray-100 text-center font-semibold">Practice / Levels</a>
+    <a href="./sandwichle.html" class="px-4 py-2 rounded bg-blue-500 text-gray-100 text-center font-semibold">Practice</a>
     <a href="./how-to-play.html" class="px-4 py-2 rounded bg-gray-700 text-gray-100 text-center font-semibold">How to Play</a>
   </div>
   <script>
-    const streak = localStorage.getItem('sandwichle-streak') || 0;
-    document.getElementById('streak').textContent = `Current Streak: ${streak}`;
+    const streak = parseInt(localStorage.getItem('sandwichle-streak') || '0', 10);
+    const history = JSON.parse(localStorage.getItem('sandwichle-history') || '[]');
+    const gamesPlayed = history.length;
+    const gamesWon = history.filter(h => h.win).length;
+    const winPct = gamesPlayed ? Math.round((gamesWon / gamesPlayed) * 100) : 0;
+    document.getElementById('stats').innerHTML = `Current Streak: ${streak}<br>Games Played: ${gamesPlayed}<br>Games Won: ${gamesWon} (${winPct}%)`;
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Consolidate landing page to a single Practice button and surface streak, play, win and percentage stats
- Remove in-game streak and trophy header for a cleaner puzzle view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a140fb222883229d47d02f1a602204