### PR TITLE
Revamp sandwichle layout and expand category list

### DIFF
--- a/public/engine/words.js
+++ b/public/engine/words.js
@@ -44,6 +44,17 @@ async function loadList(slug) {
   if (filtered.length !== uniq.length) {
     throw new Error('Category requires all words to be the same length');
   }
+  try {
+    const extra = JSON.parse(localStorage.getItem(`sandwichle-custom-${slug}`) || '[]');
+    extra.forEach(w => {
+      const v = w.normalize('NFC').toLowerCase();
+      if (v.length === targetLen && /^[a-z]+$/.test(v) && !filtered.includes(v)) {
+        filtered.push(v);
+      }
+    });
+  } catch (e) {
+    // ignore
+  }
   filtered.sort((a,b)=>a.localeCompare(b,'en',{sensitivity:'base'}));
   return {list: filtered, info};
 }


### PR DESCRIPTION
## Summary
- Move guess counter with progress circles into the header and drop in-game stats
- Explain invalid guesses and offer a “?” helper to add missing words on the fly
- Persist user-added words per category and load them in future sessions

## Testing
- ❌ `npm test` (missing script)
- ✅ `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a14438750883228b6852030d216370