### PR TITLE
Prevent cue words from becoming targets

### DIFF
--- a/public/engine/countries.js
+++ b/public/engine/countries.js
@@ -6,13 +6,14 @@ const list = countries.map(c=>c.name);
 const SALT = import.meta.env?.VITE_COUNTRIES_SALT || 'countries';
 
 export function newGame({daily=true, attempts=14}={}) {
-  let target;
+  let idx;
   if (daily) {
     const s = seedOf(yyyyMMddUTC(), 'countries', 'default', SALT);
-    target = list[s % list.length];
+    idx = 1 + (s % (list.length - 2));
   } else {
-    target = list[Math.floor(rng(Date.now())()*list.length)];
+    idx = 1 + Math.floor(rng(Date.now())() * (list.length - 2));
   }
+  const target = list[idx];
   return createEngine(mode, list, target, attempts);
 }
 

--- a/public/engine/dates.js
+++ b/public/engine/dates.js
@@ -10,13 +10,14 @@ const list = Array.from({length: DAYS}, (_,i)=>{
 const SALT = import.meta.env?.VITE_DATES_SALT || 'dates';
 
 export function newGame({daily=true, attempts=14}={}) {
-  let target;
+  let idx;
   if (daily) {
     const s = seedOf(yyyyMMddUTC(), 'dates', 'default', SALT);
-    target = list[s % list.length];
+    idx = 1 + (s % (list.length - 2));
   } else {
-    target = list[Math.floor(rng(Date.now())()*list.length)];
+    idx = 1 + Math.floor(rng(Date.now())() * (list.length - 2));
   }
+  const target = list[idx];
   return createEngine(mode, list, target, attempts);
 }
 

--- a/public/engine/numbers.js
+++ b/public/engine/numbers.js
@@ -6,13 +6,15 @@ const SALT = import.meta.env?.VITE_NUMBERS_SALT || 'numbers';
 
 export function newGame({daily=true, attempts=14}={}) {
   const list = Array.from({length: MAX - MIN + 1}, (_,i)=>MIN+i);
-  let target;
+  const len = list.length;
+  let idx;
   if (daily) {
     const s = seedOf(yyyyMMddUTC(), 'numbers', 'default', SALT);
-    target = MIN + (s % (MAX - MIN + 1));
+    idx = 1 + (s % (len - 2));
   } else {
-    target = MIN + Math.floor(rng(Date.now())() * (MAX - MIN + 1));
+    idx = 1 + Math.floor(rng(Date.now())() * (len - 2));
   }
+  const target = list[idx];
   return createEngine(mode, list, target, attempts);
 }
 

--- a/public/engine/pokemon.js
+++ b/public/engine/pokemon.js
@@ -6,13 +6,14 @@ const list = pokemon.map(p=>p.name.toLowerCase());
 const SALT = import.meta.env?.VITE_POKEMON_SALT || 'pokemon';
 
 export function newGame({daily=true, attempts=14}={}) {
-  let target;
+  let idx;
   if (daily) {
     const s = seedOf(yyyyMMddUTC(), 'pokemon', 'default', SALT);
-    target = list[s % list.length];
+    idx = 1 + (s % (list.length - 2));
   } else {
-    target = list[Math.floor(rng(Date.now())()*list.length)];
+    idx = 1 + Math.floor(rng(Date.now())() * (list.length - 2));
   }
+  const target = list[idx];
   return createEngine(mode, list, target, attempts);
 }
 

--- a/public/engine/words.js
+++ b/public/engine/words.js
@@ -70,9 +70,9 @@ export async function newGame({daily=true, category='general'}={}) {
   let idx;
   if (daily) {
     const s = seedOf(yyyyMMddUTC(), 'words', category, SALT);
-    idx = s % list.length;
+    idx = 1 + (s % (len - 2));
   } else {
-    idx = Math.floor(rng(Date.now())()*list.length);
+    idx = 1 + Math.floor(rng(Date.now())() * (len - 2));
   }
   const target = list[idx];
 


### PR DESCRIPTION
## Summary
- avoid selecting first or last list entries as targets in all game engines so the secret never matches a cue

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a149aea2748322824f234d53549de9