### PR TITLE
Add fantasy basketball auction tool

### DIFF
--- a/public/auction.js
+++ b/public/auction.js
@@ -1,0 +1,77 @@
+const weightInputs = [
+  { key: 'pts', label: 'Points', default: 1 },
+  { key: 'tpm', label: '3PM', default: 1 },
+  { key: 'fga', label: 'FGA', default: -1 },
+  { key: 'fgm', label: 'FGM', default: 2 },
+  { key: 'fta', label: 'FTA', default: -1 },
+  { key: 'ftm', label: 'FTM', default: 1 },
+  { key: 'reb', label: 'Rebounds', default: 1 },
+  { key: 'ast', label: 'Assists', default: 2 },
+  { key: 'stl', label: 'Steals', default: 4 },
+  { key: 'blk', label: 'Blocks', default: 4 },
+  { key: 'to', label: 'Turnovers', default: -2 },
+];
+
+const weightsDiv = document.getElementById('weights');
+const inputs = {};
+weightInputs.forEach(w => {
+  const label = document.createElement('label');
+  label.className = 'flex items-center gap-2';
+  label.innerHTML = `<span class="w-32">${w.label}</span><input type="number" class="text-black w-20 p-1 rounded" id="w-${w.key}" value="${w.default}" />`;
+  weightsDiv.appendChild(label);
+  inputs[w.key] = document.getElementById(`w-${w.key}`);
+});
+
+let players = [];
+
+async function loadPlayers() {
+  const res = await fetch('./data/players.json');
+  players = await res.json();
+  computeAndRender();
+}
+
+function getWeights() {
+  const w = {};
+  for (const key in inputs) w[key] = parseFloat(inputs[key].value) || 0;
+  return w;
+}
+
+function computeAndRender() {
+  const w = getWeights();
+  players.forEach(p => {
+    p.fppg =
+      p.pts * w.pts +
+      p.tpm * w.tpm +
+      p.fga * w.fga +
+      p.fgm * w.fgm +
+      p.fta * w.fta +
+      p.ftm * w.ftm +
+      p.reb * w.reb +
+      p.ast * w.ast +
+      p.stl * w.stl +
+      p.blk * w.blk +
+      p.to * w.to;
+  });
+  const replacement = Math.min(...players.map(p => p.fppg));
+  const totalPar = players.reduce((sum, p) => sum + (p.fppg - replacement), 0);
+  players.forEach(p => {
+    p.value = totalPar ? ((p.fppg - replacement) / totalPar) * 2000 : 0;
+  });
+  renderTable();
+}
+
+function renderTable() {
+  const body = document.getElementById('players-body');
+  body.innerHTML = '';
+  players
+    .slice()
+    .sort((a, b) => b.fppg - a.fppg)
+    .forEach(p => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${p.name}</td><td class="text-right">${p.fppg.toFixed(1)}</td><td class="text-right">$${p.value.toFixed(0)}</td>`;
+      body.appendChild(tr);
+    });
+}
+
+document.getElementById('apply').addEventListener('click', computeAndRender);
+loadPlayers();

--- a/public/data/players.json
+++ b/public/data/players.json
@@ -1,0 +1,47 @@
+[
+  {
+    "name": "Nikola Jokic",
+    "team": "DEN",
+    "pts": 26.4,
+    "tpm": 1.2,
+    "fga": 17.0,
+    "fgm": 11.0,
+    "fta": 5.5,
+    "ftm": 4.8,
+    "reb": 12.4,
+    "ast": 8.9,
+    "stl": 1.4,
+    "blk": 0.7,
+    "to": 3.1
+  },
+  {
+    "name": "Luka Doncic",
+    "team": "DAL",
+    "pts": 28.4,
+    "tpm": 2.8,
+    "fga": 21.5,
+    "fgm": 9.9,
+    "fta": 7.5,
+    "ftm": 6.8,
+    "reb": 8.7,
+    "ast": 8.9,
+    "stl": 1.3,
+    "blk": 0.5,
+    "to": 4.0
+  },
+  {
+    "name": "Shai Gilgeous-Alexander",
+    "team": "OKC",
+    "pts": 27.1,
+    "tpm": 1.1,
+    "fga": 19.0,
+    "fgm": 9.3,
+    "fta": 8.0,
+    "ftm": 7.5,
+    "reb": 5.1,
+    "ast": 6.2,
+    "stl": 1.7,
+    "blk": 0.8,
+    "to": 2.8
+  }
+]

--- a/public/fantasy-auction.html
+++ b/public/fantasy-auction.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+  <title>Fantasy Basketball Auction Tool</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-900 text-gray-100 p-4">
+  <h1 class="text-2xl font-semibold mb-4">Fantasy Basketball Auction Tool</h1>
+  <section id="settings" class="mb-4">
+    <h2 class="text-xl mb-2">Scoring Settings</h2>
+    <div id="weights" class="grid grid-cols-2 gap-2"></div>
+    <button id="apply" class="mt-2 px-4 py-2 bg-blue-500 rounded">Apply Weights</button>
+  </section>
+  <section>
+    <h2 class="text-xl mb-2">Player Projections</h2>
+    <table class="min-w-full text-sm" id="players-table">
+      <thead>
+        <tr>
+          <th class="text-left">Player</th>
+          <th class="text-right">FPPG</th>
+          <th class="text-right">Value ($)</th>
+        </tr>
+      </thead>
+      <tbody id="players-body"></tbody>
+    </table>
+  </section>
+  <script type="module" src="./auction.js"></script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
   <div class="flex flex-col gap-2 w-64">
     <a href="./sandwichle.html" class="px-4 py-2 rounded bg-blue-500 text-gray-100 text-center font-semibold">Practice</a>
     <a href="./how-to-play.html" class="px-4 py-2 rounded bg-gray-700 text-gray-100 text-center font-semibold">How to Play</a>
+    <a href="./fantasy-auction.html" class="px-4 py-2 rounded bg-green-600 text-gray-100 text-center font-semibold">Fantasy Auction Tool</a>
   </div>
   <script>
     const streak = parseInt(localStorage.getItem('sandwichle-streak') || '0', 10);


### PR DESCRIPTION
## Summary
- add fantasy auction page with scoring customization and player projection table
- implement client-side calculation of FPPG and auction values
- seed sample projection data and link tool from main index

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a62de49df8832280d9192877f784b9